### PR TITLE
feat(docs): Add a separate page for SimulationParameter and landing page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ __pycache__
 test.db
 test.py
 out.txt
-docs/openapi.json
+docs/*.json

--- a/docs.py
+++ b/docs.py
@@ -1,8 +1,24 @@
 """generate openapi docs."""
-from honeybee_model_schema.openapi import get_openapi
+from honeybee_model_schema._openapi import get_openapi
+from honeybee_model_schema.model import Model
+from honeybee_model_schema.energy.simulation import SimulationParameter
+
 import json
 
-print('Generating documentation...')
-openapi = get_openapi()
-with open('./docs/openapi.json', 'w') as out_file:
+# generate Model open api schema
+print('Generating Model documentation...')
+openapi = get_openapi(
+    [Model],
+    title='Honeybee Model Schema',
+    description='This is the documentation for Honeybee model schema.')
+with open('./docs/model.json', 'w') as out_file:
+    json.dump(openapi, out_file, indent=2)
+
+# generate SimulationParameter open api schema
+print('Generating Energy Simulation Parameter documentation...')
+openapi = get_openapi(
+    [SimulationParameter],
+    title='Honeybee Energy Simulation Parameter Schema',
+    description='This is the documentation for Honeybee energy simulation parameter schema.')
+with open('./docs/simulation-parameter.json', 'w') as out_file:
     json.dump(openapi, out_file, indent=2)

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-<title>Honeybee Model Schema</title>
+<title>Honeybee Schema</title>
 <!-- needed for adaptive design -->
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -10,14 +10,59 @@
 
 <link rel="shortcut icon" href="https://user-images.githubusercontent.com/2915573/53690998-7239bb00-3d43-11e9-85b1-d9ac9d140c0f.png">
 <style>
-  body {
+  img {
+    height: 50%;
     margin: 0;
-    padding: 0;
+    position: absolute;
+    top: 40%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
+
+  .title {
+    margin: 0;
+    position: absolute;
+    top: 10%;
+    left: 50%;
+    transform: translate(-50%, 0%);
+    font-size: 150%;
+    font-family: "Montserrat";
+    color: DarkBlue;
+  }
+
+  .doc-link {
+    margin: 0;
+    position: absolute;
+    top: 70%;
+    left: 50%;
+    transform: translate(-50%, 0%);
+    font-size: 125%;
+    font-family: "Montserrat";
+    text-align: center;
+  }
+
+  a:link {
+    text-decoration: none;
+    color: grey;
+  }
+
+  a:visited {
+  color: grey;
+  }
+
+  a:hover {
+  color: DarkBlue;
   }
 </style>
 </head>
 <body>
-<redoc spec-url="./openapi.json"></redoc>
-<script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+  <div class="title">Honeybee Schemas</div>
+<div>
+  <img src="https://www.ladybug.tools/assets/img/honeybee-large.png"/>
+</div>
+<div class="doc-link">
+  <a href="./model.html">Model Schema</a><br>
+  <a href="./simulation-parameter.html">Energy Simulation Parameter Schema</a>
+</div>
 </body>
 </html>

--- a/docs/model.html
+++ b/docs/model.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Honeybee Model Schema</title>
+<!-- needed for adaptive design -->
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+<link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+
+<link rel="shortcut icon" href="https://user-images.githubusercontent.com/2915573/53690998-7239bb00-3d43-11e9-85b1-d9ac9d140c0f.png">
+<style>
+  body {
+    margin: 0;
+    padding: 0;
+  }
+</style>
+</head>
+<body>
+<redoc spec-url="./model.json"></redoc>
+<script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+</body>
+</html>

--- a/docs/simulation-parameter.html
+++ b/docs/simulation-parameter.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Honeybee Model Schema</title>
+<!-- needed for adaptive design -->
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+<link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+
+<link rel="shortcut icon" href="https://user-images.githubusercontent.com/2915573/53690998-7239bb00-3d43-11e9-85b1-d9ac9d140c0f.png">
+<style>
+  body {
+    margin: 0;
+    padding: 0;
+  }
+</style>
+</head>
+<body>
+<redoc spec-url="./simulation-parameter.json"></redoc>
+<script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+</body>
+</html>

--- a/honeybee_model_schema/_base.py
+++ b/honeybee_model_schema/_base.py
@@ -1,4 +1,4 @@
-"""Base class for all objects requiring a valid EnergyPlus name."""
+"""Base class for all objects requiring a valid names for all engines."""
 from pydantic import BaseModel, Schema, validator
 
 
@@ -11,11 +11,11 @@ class NamedBaseModel(BaseModel):
         min_length=1,
         max_length=100,
         description='Name of the object used in all simulation engines. Must not '
-            'contain spaces, use only letters, digits and underscores, and not be '
-            'more than 100 characters.'
+            'contain spaces and use only letters, digits and underscores/dashes. '
+            'It cannot be longer than 100 characters.'
     )
 
     display_name: str = Schema(
         default=None,
-        description='Display name of the object with no character restrictions.'
+        description='Display name of the object with no restrictions.'
     )

--- a/honeybee_model_schema/_openapi.py
+++ b/honeybee_model_schema/_openapi.py
@@ -1,17 +1,17 @@
 from pydantic.schema import schema
 from typing import Dict
 
-from ..model import Model
 
+# base open api dictionary for all schemas
 _base_open_api = {
     "openapi": "3.0.2",
     "servers": [],
     "info": {
-        "description": "This is the documentation for Honeybee model schema.",
+        "description": "",
         "version": "1.0.0",
-        "title": "Honeybee Model Schema",
+        "title": "",
         "contact": {
-            "name": "Honeybee Data Model Support",
+            "name": "Ladybug Tools",
             "email": "info@ladybug.tools",
             "url": "https://github.com/ladybug-tools/honeybee"
         },
@@ -25,7 +25,7 @@ _base_open_api = {
         }
     },
     "externalDocs": {
-        "description": "See how to use this model in action.",
+        "description": "See how to use these schema in action.",
         "url": "https://api.pollination.cloud/"
     },
     "tags": [],
@@ -41,7 +41,7 @@ _base_open_api = {
 
 
 def get_openapi(
-    *,
+    base_object,
     title: str = None,
     version: str = None,
     openapi_version: str = "3.0.2",
@@ -61,7 +61,7 @@ def get_openapi(
     if description:
         open_api['info']['description'] = description
 
-    definitions = schema([Model], ref_prefix='#/components/schemas/')
+    definitions = schema(base_object, ref_prefix='#/components/schemas/')
 
     # goes to tags
     tags = []

--- a/honeybee_model_schema/energy/_base.py
+++ b/honeybee_model_schema/energy/_base.py
@@ -9,8 +9,8 @@ class NamedEnergyBaseModel(BaseModel):
         ...,
         min_length=1,
         max_length=100,
-        description='Name of the object used in EnergyPlus. Must use only ASCII '
-            'characters, avoid (, ; ! \\n \\t), and not be more than 100 characters.'
+        description='Name of the object. Must use only ASCII characters and '
+            'exclude (, ; ! \\n \\t). It cannot be longer than 100 characters.'
     )
 
     @validator('name')


### PR DESCRIPTION
This commit adds a separate web page for the energy SimulationParameter schema and a landing page that allows people to select which docs they would like to view.

I also cleaned up some of the descriptions of the schema keys.

@mostaphaRoudsari , as you said, you don't need to review this one but I just wanted you to be aware of this PR since it include the change to making a consistent `_openapi` module that is able to export the schema of any pydantic class that is passed to it.